### PR TITLE
Feature/git modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tech-challenge-ms-product"]
 	path = tech-challenge-ms-product
-	url = git@github.com:souzamarcos/tech-challenge-ms-product.git
+	url = https://github.com/souzamarcos/tech-challenge-ms-product.git
 [submodule "tech-challenge-ms-order"]
 	path = tech-challenge-ms-order
-	url = git@github.com:souzamarcos/tech-challenge-ms-order.git
+	url = https://github.com/souzamarcos/tech-challenge-ms-order.git

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Repositório central para o tech challenge da pós da FIAP
 Para executar todas as aplicações será necessário baixar o código dos repositórios:
 
 ```bash
-git pull --recurse-submodules
+git submodule update --init 
 ```
 
 Após isso basta iniciar o docker-compose


### PR DESCRIPTION
Alterado README para instruir os usuários a utilizar 'git submodule update --init' em vez de 'git submodule --recurse-submodules' para inicializar os submódulos.
Atualizadas as URLs dos submódulos para utilizar HTTPS em vez de SSH.





